### PR TITLE
upgraded debconf module

### DIFF
--- a/library/debconf
+++ b/library/debconf
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 """
-Ansible module to configure debian packages.
+Ansible module to configure .deb packages.
 (c) 2014, Brian Coca <briancoca+ansible@gmail.com>
 
 This file is part of Ansible
@@ -24,14 +24,17 @@ along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 DOCUMENTATION = '''
 ---
 module: debconf
-short_description: Configure a debian package
+short_description: Configure a .deb package
 description:
-     - Configure a Debian package using debconf-set-selections
-version_added: "1.5"
+     - Configure a .deb package using debconf-set-selections. Or just query
+       existing selections.
+version_added: "1.6"
 notes:
+    - This module requires the command line debconf tools.
     - A number of questions have to be answered (depending on the package).
-      Use 'debconf-show <package>' on any debian/derivative with the package
+      Use 'debconf-show <package>' on any Debian or derivative with the package
       installed to see questions/settings available.
+requirements: [ debconf, debconf-utils ]
 options:
   name:
     description:
@@ -39,15 +42,15 @@ options:
     required: true
     default: null
     aliases: ['pkg']
-  setting:
+  question:
     description:
       - A debconf configuration setting
     required: false
     default: null
-    aliases: ['question', 'selection']
-  type:
+    aliases: ['setting', 'selection']
+  vtype:
     description:
-      - The type of value supplied
+      - The type of the value supplied
     required: false
     default: null
     choices: [string, boolean, select, multiselect, note, text, password, title]
@@ -57,10 +60,10 @@ options:
       -  Value to set the configuration to
     required: false
     default: null
-    aliases: ['awnser']
+    aliases: ['answer']
   unseen:
     description:
-      - Do not set 'seen' flag when preseeding
+      - Do not set 'seen' flag when pre-seeding
     required: false
     default: False
     aliases: []
@@ -70,64 +73,65 @@ author: Brian Coca
 
 EXAMPLES = '''
 # Set default locale to fr_FR.UTF-8
-debconf: name=locales setting='locales/default_environment_locale' value=fr_FR.UTF-8
+debconf: name=locales question='locales/default_environment_locale' value=fr_FR.UTF-8
 
 # set to generate locales:
-debconf: name=locales setting='locales/locales_to_be_generated  value='en_US.UTF-8 UTF-8, fr_FR.UTF-8 UTF-8'
+debconf: name=locales question='locales/locales_to_be_generated'  value='en_US.UTF-8 UTF-8, fr_FR.UTF-8 UTF-8'
 
 # Accept oracle license
-debconf: names='oracle-java7-installer' question='shared/accepted-oracle-license-v1-1' value='true' type='select'
+debconf: name='oracle-java7-installer' question='shared/accepted-oracle-license-v1-1' value='true' vtype='select'
+
+# Specifying package you can register/return the list of questions and current values
+debconf: name='tzdata'
 '''
+
+import pipes
 
 def get_selections(module, pkg):
     cmd = [module.get_bin_path('debconf-show', True), pkg]
     rc, out, err = module.run_command(' '.join(cmd))
 
-    if rc == 0:
-        selections = {}
-	for line in out.splitlines():
-            #if not line.startswith('*'): # only awnsered
-            #    continue
-            (key, value) = line.split(':')
-            selections[ key.strip('*').strip() ] = value.strip()
-        return selections
-    else:
+    if rc != 0:
         module.fail_json(msg=err)
 
+    selections = {}
 
-def set_selection(module, pkg, question, type, value, unseen):
+    for line in out.splitlines():
+        (key, value) = line.split(':', 1)
+        selections[ key.strip('*').strip() ] = value.strip()
 
-    awnser = [ question ]
-    if 'type':
-        awnser.append(type)
-    awnser.append(value)
+    return selections
 
-    data = ' '.join(awnser)
+
+def set_selection(module, pkg, question, vtype, value, unseen):
+
+    data = ' '.join([ question, vtype, value ])
 
     setsel = module.get_bin_path('debconf-set-selections', True)
-    cmd = ["echo '%s %s' |" % (pkg, data), setsel]
+    cmd = ["echo %s %s |" % (pipes.quote(pkg), pipes.quote(data)), setsel]
     if unseen:
         cmd.append('-u')
 
-    return module.run_command(' '.join(cmd))
+    return module.run_command(' '.join(cmd), use_unsafe_shell=True)
 
 def main():
 
     module = AnsibleModule(
         argument_spec = dict(
            name = dict(required=True, aliases=['pkg'], type='str'),
-           setting = dict(required=False, aliases=['question', 'selection'], type='str'),
-           type = dict(required=False, type='str', choices=['string', 'boolean', 'select',  'multiselect', 'note', 'text', 'password', 'title']),
+           question = dict(required=False, aliases=['setting', 'selection'], type='str'),
+           vtype = dict(required=False, type='str', choices=['string', 'boolean', 'select',  'multiselect', 'note', 'text', 'password', 'title']),
            value= dict(required=False, type='str'),
            unseen = dict(required=False, type='bool'),
         ),
+        required_together = ( ['question','vtype', 'value'],),
         supports_check_mode=True,
     )
 
-    #TODO: enable passing array of optionas and/or debconf file from get-selections dump
+    #TODO: enable passing array of options and/or debconf file from get-selections dump
     pkg      = module.params["name"]
-    question = module.params["setting"]
-    type     = module.params["type"]
+    question = module.params["question"]
+    vtype    = module.params["vtype"]
     value    = module.params["value"]
     unseen   = module.params["unseen"]
 
@@ -138,27 +142,29 @@ def main():
     msg = ""
 
     if question is not None:
+        if vtype is None or value is None:
+            module.fail_json(msg="when supplying a question you must supply a valid vtype and value")
+
         if not question in prev or prev[question] != value:
             changed = True
 
     if changed:
         if not module.check_mode:
-            rc, msg, e = set_selection(module, pkg, question, type, value, unseen)
+            rc, msg, e = set_selection(module, pkg, question, vtype, value, unseen)
             if rc:
                 module.fail_json(msg=e)
 
         curr = { question: value }
         if question in prev:
-	        prev = {question: prev[question]}
+            prev = {question: prev[question]}
         else:
-	        prev[question] = ''
+            prev[question] = ''
 
         module.exit_json(changed=changed, msg=msg, current=curr, previous=prev)
 
     module.exit_json(changed=changed, msg=msg, current=prev)
 
-# this is magic, see lib/ansible/module_common.py
-#<<INCLUDE_ANSIBLE_MODULE_COMMON>>
+# import module snippets
+from ansible.module_utils.basic import *
+
 main()
-
-

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,21 +1,21 @@
     - name: Setup oracle java deb repo
       apt_repository: repo="ppa:webupd8team/java" update_cache=yes
-      when: ansible_distribution in [ 'Ubuntu' ] 
-      
+      when: ansible_distribution in [ 'Ubuntu' ]
+
     - name: Add webupd8 repo apt-key
       apt_key: url=http://keyserver.ubuntu.com:11371/pks/lookup?op=get&search=0xC2518248EEA14886 state=present
-      when: ansible_distribution in [ 'Debian' ] 
-  
+      when: ansible_distribution in [ 'Debian' ]
+
     - name: Add webupd8 repository on Debian
       apt_repository: repo='deb http://ppa.launchpad.net/webupd8team/java/ubuntu precise main' state=present
-      when: ansible_distribution in [ 'Debian' ] 
-    
+      when: ansible_distribution in [ 'Debian' ]
+
     - name: Add webupd8 repository (src) on Debian
       apt_repository: repo='deb-src http://ppa.launchpad.net/webupd8team/java/ubuntu precise main' state=present
-      when: ansible_distribution in [ 'Debian' ] 
+      when: ansible_distribution in [ 'Debian' ]
 
     - name: Accept Oracle license
-      debconf: name="oracle-java7-installer" setting="shared/accepted-oracle-license-v1-1" type="select" value="true"
+      debconf: name="oracle-java7-installer" setting="shared/accepted-oracle-license-v1-1" vtype="select" value="true"
 
     - name: Install packages
       apt: name={{item}} state=present update_cache=yes


### PR DESCRIPTION
I noticed a lot of issues with accepting the oracle license when trying to deploy on Debian. Since Ansible 1.6 isn't released yet I added the latest debconf library from ansible development. This requires a change of the type argument to type (which makes this role more compatible with Ansible 1.6 as well).
