### PR TITLE
Update debconf to use 1.6 syntax

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,7 +15,7 @@
       when: ansible_distribution in [ 'Debian' ] 
 
     - name: Accept Oracle license
-      debconf: name="oracle-java7-installer" setting="shared/accepted-oracle-license-v1-1" type="select" value="true"
+      debconf: name="oracle-java7-installer" question='shared/accepted-oracle-license-v1-1' value='true' vtype='select'
 
     - name: Install packages
       apt: name={{item}} state=present update_cache=yes


### PR DESCRIPTION
Updates Accept Oracle License task to use syntax documented in 1.6 release.
