### PR TITLE
Wrap oracle_packages in braces for ansible 2.2

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -22,4 +22,4 @@
 
     - name: Install packages
       apt: name={{item}} state=present update_cache=yes
-      with_items: oracle_packages
+      with_items: '{{oracle_packages}}'


### PR DESCRIPTION
Hi,

Ansible 2.2 wants the oracle_packages variable wrapped in braces.  Here's a PR for it.

Thanks,

Brian